### PR TITLE
fortran: Fix finalization memory leak in nested derived types

### DIFF
--- a/gcc/fortran/class.cc
+++ b/gcc/fortran/class.cc
@@ -1042,17 +1042,21 @@ finalize_component (gfc_expr *expr, gfc_symbol *derived, gfc_component *comp,
   gfc_expr *e;
   gfc_ref *ref;
   gfc_was_finalized *f;
+  tree obj_addr;
 
   if (!comp_is_finalizable (comp))
     return;
 
-  /* If this expression with this component has been finalized
-     already in this namespace, there is nothing to do.  */
+  /* -----------------------------------------------------------------
+     Use the address of the *actual data object* as the key; identical
+     addresses mean that we have already visited this particular
+     instance of the component.  */
+  obj_addr = gfc_build_addr_expr (pvoid_type_node,
+			gfc_convert_expr_to_tree (expr, true));
+
   for (f = sub_ns->was_finalized; f; f = f->next)
-    {
-      if (f->e == expr && f->c == comp)
-	return;
-    }
+    if (f->c == comp && operand_equal_p (f->addr, obj_addr, 0))
+      return;
 
   e = gfc_copy_expr (expr);
   if (!e->ref)
@@ -1228,12 +1232,12 @@ finalize_component (gfc_expr *expr, gfc_symbol *derived, gfc_component *comp,
       gfc_free_expr (e);
     }
 
-  /* Record that this was finalized already in this namespace.  */
+  /* remember this instance                                           */
   f = sub_ns->was_finalized;
-  sub_ns->was_finalized = XCNEW (gfc_was_finalized);
-  sub_ns->was_finalized->e = expr;
-  sub_ns->was_finalized->c = comp;
-  sub_ns->was_finalized->next = f;
+  sub_ns->was_finalized           = XCNEW (gfc_was_finalized);
+  sub_ns->was_finalized->addr     = obj_addr;
+  sub_ns->was_finalized->c        = comp;
+  sub_ns->was_finalized->next     = f;
 }
 
 

--- a/gcc/fortran/gfortran.h
+++ b/gcc/fortran/gfortran.h
@@ -2209,7 +2209,7 @@ gfc_oacc_routine_name;
    earlier.  */
 
 typedef struct gfc_was_finalized {
-  gfc_expr *e;
+  tree addr;                    /* run-time address of object */
   gfc_component *c;
   struct gfc_was_finalized *next;
 }


### PR DESCRIPTION
## Summary

Fixes a use-after-free bug in the Fortran finalization cache that caused memory leaks when finalizing nested derived types with multiple components of the same type containing allocatable arrays.

## Problem Description

The issue occurred in the following scenario:
1. A parent derived type has multiple components of the **same** derived type
2. The inner derived type contains allocatable components  
3. The finalization logic uses a cache (`was_finalized`) to prevent redundant finalization
4. The cache key was `(gfc_expr *e, gfc_component *c)` where `e` is a **pointer identity**
5. Local `gfc_expr` objects created during finalization are freed, making cache entries stale
6. Memory reuse causes false cache hits, skipping subsequent component finalization

## Root Cause

The finalization cache used `gfc_expr*` pointers as cache keys. These pointers become stale when the local expression objects are freed, leading to false positive cache hits when memory addresses are reused for sibling components.

## Solution

Replace the unreliable `gfc_expr*` pointer-based cache key with the **runtime address** of the actual data object being finalized:

- **Structure Change**: Replace `gfc_expr *e` with `tree addr` in `gfc_was_finalized`
- **Cache Logic**: Use `gfc_build_addr_expr()` to get the runtime object address
- **Comparison**: Use `operand_equal_p()` to compare runtime addresses instead of pointer equality

## Benefits

1. **Eliminates Use-After-Free**: Runtime addresses don't become invalid like expression pointers
2. **Unique Component Identification**: Each component instance has a unique runtime address
3. **Proper Sibling Handling**: Different sibling components have different addresses and are processed separately
4. **Maintains Cache Effectiveness**: Still prevents duplicate finalization of the same instance

## Files Changed

- `gcc/fortran/gfortran.h`: Update `gfc_was_finalized` structure
- `gcc/fortran/class.cc`: Update cache logic in `finalize_component()`

## Testing

This bug is difficult to reproduce reliably due to the randomness in memory allocation patterns. The fix has been designed based on careful analysis of the code paths and should resolve the underlying use-after-free issue.

---

**Note**: This PR was generated by AI Assistant and inspired by analysis from Gemini 2.5 Pro and o3-pro.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author